### PR TITLE
Fixing syntax error in p5.js snippet

### DIFF
--- a/snippets/markdown/image/tensorflowjs/p5js.md
+++ b/snippets/markdown/image/tensorflowjs/p5js.md
@@ -10,9 +10,6 @@ Open up the code snippet below directly in the [p5.js Web Editor](https://editor
   let classifier;
   // Model URL
   let imageModelURL = '{{URL}}';
-
-  // Classifier Variable
-  let classifier;
   
   // Video
   let video;


### PR DESCRIPTION
In the code snippet for p5.js was a syntax error (the variable 'classifier' was declared twice) which caused the snippet not to work.