### PR TITLE
[fix] Bumps ml5 version to 0.4.3

### DIFF
--- a/snippets/markdown/audio/tensorflowjs/p5js.md
+++ b/snippets/markdown/audio/tensorflowjs/p5js.md
@@ -4,7 +4,7 @@ Open up the code snippet below directly in the [p5.js Web Editor](https://editor
 <div>Teachable Machine Audio Model - p5.js and ml5.js</div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-<script src="https://unpkg.com/ml5@0.4.2/dist/ml5.min.js"></script>
+<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js"></script>
 <script type="text/javascript">
   // Global variable to store the classifier
 let classifier;

--- a/snippets/markdown/image/tensorflowjs/p5js.md
+++ b/snippets/markdown/image/tensorflowjs/p5js.md
@@ -4,7 +4,7 @@ Open up the code snippet below directly in the [p5.js Web Editor](https://editor
 <div>Teachable Machine Image Model - p5.js and ml5.js</div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-<script src="https://unpkg.com/ml5@0.4.2/dist/ml5.min.js"></script>
+<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js"></script>
 <script type="text/javascript">
   // Classifier Variable
   let classifier;


### PR DESCRIPTION
Hi!

This PR addresses https://github.com/googlecreativelab/teachablemachine-community/issues/39.

* ml5 version 0.4.3 takes care of the memory leak in the image classifier
* this PR bumps the ml5 version to 0.4.3 

Let me know if you have any questions or requests!

Thanks!