### PR TITLE
image.resize((224, 224)) returns a resized copy

### DIFF
--- a/snippets/markdown/image/tensorflow/keras.md
+++ b/snippets/markdown/image/tensorflow/keras.md
@@ -18,7 +18,7 @@ data = np.ndarray(shape=(1, 224, 224, 3), dtype=np.float32)
 image = Image.open('Path to your image')
 
 # Make sure to resize all images to 224, 224 otherwise they won't fit in the array
-image.resize((224, 224))
+image = image.resize((224, 224))
 image_array = np.asarray(image)
 
 # Normalize the image


### PR DESCRIPTION
image.resize((224, 224)) returns a resized copy - which was not used in the previous version, thus it would only work with images that already have the correct size