### PR TITLE
Improve compatibility outside of web browsers

### DIFF
--- a/libraries/image/src/utils/canvas.ts
+++ b/libraries/image/src/utils/canvas.ts
@@ -47,7 +47,7 @@ export function cropTo( image: Drawable, size: number,
     let height = image.height;
 
     // if video element
-    if (image instanceof HTMLVideoElement) {
+    if (typeof HTMLVideoElement != 'undefined' && image instanceof HTMLVideoElement) {
         width = (image as HTMLVideoElement).videoWidth;
         height = (image as HTMLVideoElement).videoHeight;
     }


### PR DESCRIPTION
Checking if HTMLVideoElement is available prevents `An error occurred: HTMLVideoElement is not defined ReferenceError: HTMLVideoElement is not defined` errors when used outside of an web browser.

A similar change has been made by [tr7zw](https://github.com/tr7zw/teachablemachine-node-example) as he stated in #33.

A workaround is still required to get it working outside of a browser but not needing to remove the line would make package-managing easier.