### PR TITLE
Update ml5 version number to @latest

### DIFF
--- a/snippets/markdown/audio/tensorflowjs/p5js.md
+++ b/snippets/markdown/audio/tensorflowjs/p5js.md
@@ -4,7 +4,7 @@ Open up the code snippet below directly in the [p5.js Web Editor](https://editor
 <div>Teachable Machine Audio Model - p5.js and ml5.js</div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js"></script>
+<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js"></script>
 <script type="text/javascript">
   // Global variable to store the classifier
 let classifier;

--- a/snippets/markdown/image/tensorflowjs/p5js.md
+++ b/snippets/markdown/image/tensorflowjs/p5js.md
@@ -4,7 +4,7 @@ Open up the code snippet below directly in the [p5.js Web Editor](https://editor
 <div>Teachable Machine Image Model - p5.js and ml5.js</div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js"></script>
+<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js"></script>
 <script type="text/javascript">
   // Classifier Variable
   let classifier;


### PR DESCRIPTION
We recently released the 0.5.0 release version of [ml5](https://github.com/ml5js/ml5-library). This PR updating examples here to specify the new version. 

I wonder if we should specify @latest here instead though cc @joeyklee.

EDIT
Switched to @latest instead of a specific version number.