### PR TITLE
Adding Node-RED node under Community Contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Teachable Machine Community
-
 ![Teachable Machine](./teachablemachine.gif)
 
 ### What is Teachable Machine?
-
 [Teachable Machine](https://teachablemachine.withgoogle.com/) is a web-based tool that makes creating machine learning models fast, easy, and accessible for everyone. [You can try it here](https://teachablemachine.withgoogle.com/).
 
 ### Who is it for?
@@ -13,7 +11,6 @@ Educators, artists, students, innovators, makers of all kinds – really, anyone
 You train a computer to recognize your images, sounds, and poses without writing any machine learning code. Then, use your model in your own projects, sites, apps, and more.
 
 ### What is this repository for?
-
 This repository contains two components of [Teachable Machine](https://teachablemachine.withgoogle.com/):
 
 1. **A [libraries](/libraries) section** that contains all of the machine learning code used in Teachable Machine. Under the hood we use [Tensorflow.js](https://www.tensorflow.org/js), a library for machine learning in Javascript, to train and run the models you make in your web browser. The `libraries` section also contains the API for [image](/libraries/image), [audio](/libraries/audio), and [pose](/libraries/pose) helper libraries that make it easier to use the models exported by Teachable Machine in your own projects.
@@ -21,7 +18,6 @@ This repository contains two components of [Teachable Machine](https://teachable
 2. **A [snippets](/snippets) section** that contains markdown snippets that are being displayed inside the export panel in [Teachable Machine](https://teachablemachine.withgoogle.com/). These snippets contain code and instructions on how to use the exported models from Teachable Machine in languages like Javascript, Java and Python.
 
 ### How can I send feedback?
-
 You have a few options:
 
 * Email us at [teachablemachine-support@google.com](mailto:teachablemachine-support@google.com).
@@ -29,13 +25,12 @@ You have a few options:
 * Open an issue in this repository.
 
 ## Community Contributions and Projects
-
 * [Teachable Machine Node Library for image models](https://github.com/tr7zw/teachablemachine-node-example)
 * [Teachable Machine Mobile for image models](https://github.com/mstale007/Teachable_Machine_Mobile/tree/master)
+* [Teachable Machine Node Library for Node-RED](https://github.com/bonastreyair/node-red-contrib-teachable-machine/tree/master)
 
 
 ## Disclaimer
-
 This is an experiment, not an official Google product. We’ll do our best to support and maintain this experiment but your mileage may vary.
 
 We encourage open sourcing projects as a way of learning from each other. Please respect our and other creators’ rights, including copyright and trademark rights when present, when sharing these works and creating derivative work. If you want more info on Google's policy, you can find that [here](https://www.google.com/permissions/).


### PR DESCRIPTION
I have created a functional `Node-RED` node and I think it would be great to add it in the `README` file of the official page so that more people can easily integrate the models.

[![platform](https://img.shields.io/badge/platform-Node--RED-red)](https://nodered.org)

Check it out! 
 - [node-red-contrib-teachable-machine](https://github.com/bonastreyair/node-red-contrib-teachable-machine/tree/master)