### PR TITLE
fix ./snippets/markdown/image/edgetpu/python.md

### DIFF
--- a/snippets/markdown/image/edgetpu/python.md
+++ b/snippets/markdown/image/edgetpu/python.md
@@ -32,13 +32,8 @@ def loadLabels(labelPath):
         lines = (p.match(line).groups() for line in labelFile.readlines())
         return {int(num): text.strip() for num, text in lines}
 
-# This function takes in a PIL Image from any source or path you choose
-def classifyImage(image_path, engine):
-    # Load and format your image for use with TM2 model
-    # image is reformated to a square to match training
-    image = Image.open(image_path)
-    image.resize((224, 224))
-
+# This function takes in a PIL Image and the ClassificationEngine
+def classifyImage(image, engine):
     # Classify and ouptut inference
     classifications = engine.ClassifyWithImage(image)
     return classifications


### PR DESCRIPTION
An image is passed into classifyImage, not an image path so trying to open the image path throws an error. Then resizing the image is not needed as it has already been resized before being passed in. Description changed to include correct parameters.