### PR TITLE
fix when running demo in ios, video will be frozen

### DIFF
--- a/libraries/image/README.md
+++ b/libraries/image/README.md
@@ -59,7 +59,7 @@ import * as tmImage from '@teachablemachine/image';
     let model, webcam, labelContainer, maxPredictions;
 
     let isIos = false; 
-    // fix when demo run in ios, video will be freezed;
+    // fix when running demo in ios, video will be frozen;
     if (window.navigator.userAgent.indexOf('iPhone') > -1 || window.navigator.userAgent.indexOf('iPad') > -1) {
       isIos = true;
     }

--- a/libraries/image/README.md
+++ b/libraries/image/README.md
@@ -58,6 +58,11 @@ import * as tmImage from '@teachablemachine/image';
 
     let model, webcam, labelContainer, maxPredictions;
 
+    let isIos = false; 
+    // fix when demo run in ios, video will be freezed;
+    if (window.navigator.userAgent.indexOf('iPhone') > -1 || window.navigator.userAgent.indexOf('iPad') > -1) {
+      isIos = true;
+    }
     // Load the image model and setup the webcam
     async function init() {
         const modelURL = URL + 'model.json';
@@ -71,17 +76,29 @@ import * as tmImage from '@teachablemachine/image';
 
         // Convenience function to setup a webcam
         const flip = true; // whether to flip the webcam
-        webcam = new tmImage.Webcam(200, 200, flip); // width, height, flip
+        const width = 200;
+        const height = 200;
+        webcam = new tmImage.Webcam(width, height, flip); // width, height, flipwidth, height, flip
         await webcam.setup(); // request access to the webcam
-        webcam.play();
-        window.requestAnimationFrame(loop);
 
+        if (isIos) {
+            document.getElementById('webcam-container').appendChild(webcam.webcam); // webcam object needs to be added in any case to make this work on iOS
+            // grab video-object in any way you want and set the attributes --> **"muted" and "playsinline"**
+            const webCamVideo = document.getElementsByTagName('video')[0];
+            webCamVideo.setAttribute("playsinline", true); // written with "setAttribute" bc. iOS buggs otherwise :-)
+            webCamVideo.muted = "true";
+            webCamVideo.style.width = width + 'px';
+            webCamVideo.style.height = height + 'px';
+        } else {
+            document.getElementById("webcam-container").appendChild(webcam.canvas);
+        }
         // append elements to the DOM
-        document.getElementById('webcam-container').appendChild(webcam.canvas);
         labelContainer = document.getElementById('label-container');
         for (let i = 0; i < maxPredictions; i++) { // and class labels
             labelContainer.appendChild(document.createElement('div'));
         }
+        webcam.play();
+        window.requestAnimationFrame(loop);
     }
 
     async function loop() {
@@ -93,7 +110,12 @@ import * as tmImage from '@teachablemachine/image';
     // run the webcam image through the image model
     async function predict() {
         // predict can take in an image, video or canvas html element
-        const prediction = await model.predict(webcam.canvas);
+        let prediction;
+        if (isIos) {
+            prediction = await model.predict(webcam.webcam);
+        } else {
+            prediction = await model.predict(webcam.canvas);
+        }
         for (let i = 0; i < maxPredictions; i++) {
             const classPrediction =
                 prediction[i].className + ': ' + prediction[i].probability.toFixed(2);


### PR DESCRIPTION
In ios 14.2. When running the demo using Safari, user cant see the video running normally. And cant use `model.predict()`
thx for @derm1ch1, I used his idea.