### PR TITLE
Adds support for grayscale image models and image models with different input sizes

### DIFF
--- a/libraries/Dockerfile
+++ b/libraries/Dockerfile
@@ -6,7 +6,7 @@ FROM node:12
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    && apt-get install -y google-chrome-unstable libxtst6 libxss1 fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 

--- a/libraries/image/src/custom-mobilenet.ts
+++ b/libraries/image/src/custom-mobilenet.ts
@@ -27,7 +27,7 @@ const DEFAULT_TRAINING_LAYER_V1 = 'conv_pw_13_relu';
 const DEFAULT_TRAINING_LAYER_V2 = "out_relu"; 
 const DEFAULT_ALPHA_V1 = 0.25;
 const DEFAULT_ALPHA_V2 = 0.35;
-export let IMAGE_SIZE = 224;
+export const IMAGE_SIZE = 224;
 
 /**
  * the metadata to describe the model's creation,
@@ -44,6 +44,7 @@ export interface Metadata {
     labels: string[];
     userMetadata?: {};
     grayscale?: boolean;
+    imageSize?: number;
 }
 
 export interface ModelOptions {
@@ -51,7 +52,6 @@ export interface ModelOptions {
     checkpointUrl?: string;
     alpha?: number;
     trainingLayer?: string;
-    imageSize?: number;
 }
 
 /**
@@ -66,6 +66,7 @@ const fillMetadata = (data: Partial<Metadata>) => {
     data.userMetadata = data.userMetadata || {};
     data.modelName = data.modelName || 'untitled';
     data.labels = data.labels || [];
+    data.imageSize = data.imageSize || IMAGE_SIZE;
     return data as Metadata;
 };
 
@@ -93,9 +94,7 @@ const isAlphaValid = (version: number, alpha: number) => {
 };
 
 const parseModelOptions = (options?: ModelOptions) => {
-    options = options || {};
-
-    if (options.imageSize) IMAGE_SIZE = options.imageSize;
+    options = options || {}
 
     if (options.checkpointUrl && options.trainingLayer) {
         if (options.alpha || options.version){
@@ -256,7 +255,7 @@ export class CustomMobileNet {
      * @param flipped whether to flip the image on X
      */
     async predict(image: ClassifierInputSource, flipped = false) {
-        const croppedImage = cropTo(image, IMAGE_SIZE, flipped);
+        const croppedImage = cropTo(image, this._metadata.imageSize, flipped);
 
         const logits = tf.tidy(() => {
             const captured = capture(croppedImage, this._metadata.grayscale);

--- a/libraries/image/src/custom-mobilenet.ts
+++ b/libraries/image/src/custom-mobilenet.ts
@@ -94,11 +94,8 @@ const isAlphaValid = (version: number, alpha: number) => {
 
 const parseModelOptions = (options?: ModelOptions) => {
     options = options || {};
-    console.log(options);
-    if (options.imageSize) {
-        console.log('setting custom image size', options.imageSize)
-        IMAGE_SIZE = options.imageSize;
-    }
+
+    if (options.imageSize) IMAGE_SIZE = options.imageSize;
 
     if (options.checkpointUrl && options.trainingLayer) {
         if (options.alpha || options.version){

--- a/libraries/image/src/custom-mobilenet.ts
+++ b/libraries/image/src/custom-mobilenet.ts
@@ -27,7 +27,7 @@ const DEFAULT_TRAINING_LAYER_V1 = 'conv_pw_13_relu';
 const DEFAULT_TRAINING_LAYER_V2 = "out_relu"; 
 const DEFAULT_ALPHA_V1 = 0.25;
 const DEFAULT_ALPHA_V2 = 0.35;
-export const IMAGE_SIZE = 96;
+export let IMAGE_SIZE = 224;
 
 /**
  * the metadata to describe the model's creation,
@@ -51,6 +51,7 @@ export interface ModelOptions {
     checkpointUrl?: string;
     alpha?: number;
     trainingLayer?: string;
+    imageSize?: number;
 }
 
 /**
@@ -93,6 +94,11 @@ const isAlphaValid = (version: number, alpha: number) => {
 
 const parseModelOptions = (options?: ModelOptions) => {
     options = options || {};
+    console.log(options);
+    if (options.imageSize) {
+        console.log('setting custom image size', options.imageSize)
+        IMAGE_SIZE = options.imageSize;
+    }
 
     if (options.checkpointUrl && options.trainingLayer) {
         if (options.alpha || options.version){

--- a/libraries/image/src/custom-mobilenet.ts
+++ b/libraries/image/src/custom-mobilenet.ts
@@ -26,8 +26,8 @@ const DEFAULT_MOBILENET_VERSION = 1;
 const DEFAULT_TRAINING_LAYER_V1 = 'conv_pw_13_relu';
 const DEFAULT_TRAINING_LAYER_V2 = "out_relu"; 
 const DEFAULT_ALPHA_V1 = 0.25;
-const DEFAULT_ALPHA_V2 = 0.35; 
-export const IMAGE_SIZE = 224;
+const DEFAULT_ALPHA_V2 = 0.35;
+export const IMAGE_SIZE = 96;
 
 /**
  * the metadata to describe the model's creation,
@@ -43,6 +43,7 @@ export interface Metadata {
     timeStamp?: string;
     labels: string[];
     userMetadata?: {};
+    grayscale?: boolean;
 }
 
 export interface ModelOptions {
@@ -255,7 +256,7 @@ export class CustomMobileNet {
         const croppedImage = cropTo(image, IMAGE_SIZE, flipped);
 
         const logits = tf.tidy(() => {
-            const captured = capture(croppedImage);
+            const captured = capture(croppedImage, this._metadata.grayscale);
             return this.model.predict(captured);
         });
 

--- a/libraries/image/src/teachable-mobilenet.ts
+++ b/libraries/image/src/teachable-mobilenet.ts
@@ -146,7 +146,7 @@ export class TeachableMobileNet extends CustomMobileNet {
      */
     // public async addExample(className: number, sample: HTMLCanvasElement | tf.Tensor) {
     public async addExample(className: number, sample: HTMLImageElement | HTMLCanvasElement | tf.Tensor) {
-        const cap = isTensor(sample) ? sample : capture(sample);
+        const cap = isTensor(sample) ? sample : capture(sample, this._metadata.grayscale);
         const example = this.truncatedModel.predict(cap) as tf.Tensor;
 
         const activation = example.dataSync() as Float32Array;

--- a/libraries/image/src/utils/tf.ts
+++ b/libraries/image/src/utils/tf.ts
@@ -21,13 +21,14 @@ import * as tf from '@tensorflow/tfjs';
  * Receives an image and normalizes it between -1 and 1.
  * Returns a batched image (1 - element batch) of shape [1, w, h, c]
  * @param rasterElement the element with pixels to convert to a Tensor
+ * @param grayscale optinal flag that changes the crop to [1, w, h, 1]
  */
-export function capture(rasterElement: HTMLImageElement | HTMLVideoElement | HTMLCanvasElement ) {
+export function capture(rasterElement: HTMLImageElement | HTMLVideoElement | HTMLCanvasElement, grayscale?: boolean) {
     return tf.tidy(() => {
         const pixels = tf.browser.fromPixels(rasterElement);
 
         // crop the image so we're using the center square
-        const cropped = cropTensor(pixels);
+        const cropped = cropTensor(pixels, grayscale);
 
         // Expand the outer most dimension so we have a batch size of 1
         const batchedImage = cropped.expandDims(0);
@@ -39,11 +40,13 @@ export function capture(rasterElement: HTMLImageElement | HTMLVideoElement | HTM
 }
 
 
-export function cropTensor( img: tf.Tensor3D ) : tf.Tensor3D {
+export function cropTensor( img: tf.Tensor3D, grayscale?: boolean ) : tf.Tensor3D {
     const size = Math.min(img.shape[0], img.shape[1]);
     const centerHeight = img.shape[0] / 2;
     const beginHeight = centerHeight - (size / 2);
     const centerWidth = img.shape[1] / 2;
     const beginWidth = centerWidth - (size / 2);
-    return img.slice([beginHeight, beginWidth, 0], [size, size, 3]);
+    return grayscale ?
+           img.slice([beginHeight, beginWidth, 0], [size, size, 1]) :
+           img.slice([beginHeight, beginWidth, 0], [size, size, 3]);
 }

--- a/libraries/pose/test/pose.test.ts
+++ b/libraries/pose/test/pose.test.ts
@@ -193,13 +193,13 @@ describe('Test pose library', () => {
         poseModel = model;
         assert.isAbove(lastEpoch.acc, 0.9);
         assert.isBelow(lastEpoch.loss, 0.001);
-    }).timeout(100000);
+    }).timeout(1000000);
 
     it('test early stop', async () => {
         const { model, lastEpoch } = await testPosenet(10, 0.0001, false, 5);
         assert.isAbove(lastEpoch.acc, 0.9);
         assert.isBelow(lastEpoch.loss, 0.1);
-    }).timeout(100000);
+    }).timeout(1000000);
 
     it("Test predict functions", async () => {
         let testImage, prediction, poseResult, predictionTopK;


### PR DESCRIPTION
Custom image models can be loaded via the checkpointUrl parameter, but these changes are necessary to use models with input shape other than [, 224, 224, 3]