### PR TITLE
Update TFLite sound classification snippet

### DIFF
--- a/snippets/markdown/audio/tflite/Android.md
+++ b/snippets/markdown/audio/tflite/Android.md
@@ -2,13 +2,42 @@
 
 You can test your TensorFlow Lite sound classification model on Android by following these steps:
 
-1. Download the [sample app](https://github.com/tensorflow/examples/tree/master/lite/examples/sound_classification/android)
+1. Download the [sample app](https://github.com/tensorflow/examples/tree/master/lite/examples/sound_classification/android_legacy)
  from GitHub.
-1. Copy the `soundclassifier.tflite` file downloaded from Teachable Machine to the
+1. Extract the ZIP archive that you download from Teachable Machine.
+1. Copy the `soundclassifier.tflite` and `labels.txt` files from the archive to the
  `src/main/assets` folder in the sample app, replacing the demo model there.
 
  *Note: Please use a physical Android device to run the sample app.*
 
 ## Integrate your model into your own app
 
-You can use TFLite Task Library - AudioClassifier API to integrate the model into your Android. See the TFLite [documentation](https://www.tensorflow.org/lite/inference_with_metadata/task_library/audio_classifier) for more details.
+If you want to integrate the model into your existing app, follow these steps:
+
+1. Put the `soundclassifier.tflite` and `labels.txt` files into the `assets` folder in your app.
+1. Copy the [SoundClassifier.kt](https://github.com/tensorflow/examples/blob/master/lite/examples/sound_classification/android_legacy/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt)
+ file to your app. This file contains the source code to use the sound classification model.
+1. Initialize a `SoundClassifier` instance from your `Activity` or `Fragment` class.
+
+    ```kotlin
+    var soundClassifier: SoundClassifier
+    soundClassifier = SoundClassifier(context).also {
+        it.lifecycleOwner = context // or viewLifecycleOwner when using in a Fragment
+    }
+    ```
+
+1. Start capturing live audio from the device's microphone and classify in realtime:
+
+    ```kotlin
+    soundClassifier.start()
+    ```
+
+1. Receive classification result in realtime as a map of human-readable class name and
+ probabilities of the current sound belonging to each particular category.
+
+    ```kotlin
+    let labelName = soundClassifier.labelList[0] // e.g. "Clap"
+    soundClassifier.probabilities.observe(this) { resultMap ->
+        let probability = resultMap[labelName] // e.g. 0.7
+    }
+    ```

--- a/snippets/markdown/audio/tflite/Android.md
+++ b/snippets/markdown/audio/tflite/Android.md
@@ -2,7 +2,7 @@
 
 You can test your TensorFlow Lite sound classification model on Android by following these steps:
 
-1. Download the [sample app](https://github.com/tensorflow/examples/tree/master/lite/examples/sound_classification/android)
+1. Download the [sample app](https://github.com/tensorflow/examples/tree/master/lite/examples/sound_classification/android_legacy)
  from GitHub.
 1. Extract the ZIP archive that you download from Teachable Machine.
 1. Copy the `soundclassifier.tflite` and `labels.txt` files from the archive to the
@@ -15,7 +15,7 @@ You can test your TensorFlow Lite sound classification model on Android by follo
 If you want to integrate the model into your existing app, follow these steps:
 
 1. Put the `soundclassifier.tflite` and `labels.txt` files into the `assets` folder in your app.
-1. Copy the [SoundClassifier.kt](https://github.com/tensorflow/examples/blob/master/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt)
+1. Copy the [SoundClassifier.kt](https://github.com/tensorflow/examples/blob/master/lite/examples/sound_classification/android_legacy/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt)
  file to your app. This file contains the source code to use the sound classification model.
 1. Initialize a `SoundClassifier` instance from your `Activity` or `Fragment` class.
 

--- a/snippets/markdown/audio/tflite/Android.md
+++ b/snippets/markdown/audio/tflite/Android.md
@@ -2,42 +2,13 @@
 
 You can test your TensorFlow Lite sound classification model on Android by following these steps:
 
-1. Download the [sample app](https://github.com/tensorflow/examples/tree/master/lite/examples/sound_classification/android_legacy)
+1. Download the [sample app](https://github.com/tensorflow/examples/tree/master/lite/examples/sound_classification/android)
  from GitHub.
-1. Extract the ZIP archive that you download from Teachable Machine.
-1. Copy the `soundclassifier.tflite` and `labels.txt` files from the archive to the
+1. Copy the `soundclassifier.tflite` file downloaded from Teachable Machine to the
  `src/main/assets` folder in the sample app, replacing the demo model there.
 
  *Note: Please use a physical Android device to run the sample app.*
 
 ## Integrate your model into your own app
 
-If you want to integrate the model into your existing app, follow these steps:
-
-1. Put the `soundclassifier.tflite` and `labels.txt` files into the `assets` folder in your app.
-1. Copy the [SoundClassifier.kt](https://github.com/tensorflow/examples/blob/master/lite/examples/sound_classification/android_legacy/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt)
- file to your app. This file contains the source code to use the sound classification model.
-1. Initialize a `SoundClassifier` instance from your `Activity` or `Fragment` class.
-
-    ```kotlin
-    var soundClassifier: SoundClassifier
-    soundClassifier = SoundClassifier(context).also {
-        it.lifecycleOwner = context // or viewLifecycleOwner when using in a Fragment
-    }
-    ```
-
-1. Start capturing live audio from the device's microphone and classify in realtime:
-
-    ```kotlin
-    soundClassifier.start()
-    ```
-
-1. Receive classification result in realtime as a map of human-readable class name and
- probabilities of the current sound belonging to each particular category.
-
-    ```kotlin
-    let labelName = soundClassifier.labelList[0] // e.g. "Clap"
-    soundClassifier.probabilities.observe(this) { resultMap ->
-        let probability = resultMap[labelName] // e.g. 0.7
-    }
-    ```
+You can use TFLite Task Library - AudioClassifier API to integrate the model into your Android. See the TFLite [documentation](https://www.tensorflow.org/lite/inference_with_metadata/task_library/audio_classifier) for more details.

--- a/snippets/markdown/audio/tflite/iOS.md
+++ b/snippets/markdown/audio/tflite/iOS.md
@@ -1,0 +1,11 @@
+## Try your model with TFLite sample app
+
+You can test your TensorFlow Lite sound classification model on iOS by following these steps:
+
+1. Download the [sample app](https://github.com/tensorflow/examples/tree/master/lite/examples/sound_classification/iOS)
+ from GitHub.
+1. Extract the ZIP archive that you download from Teachable Machine.
+1. Copy the `soundclassifier.tflite` and `labels.txt` files from the archive to the
+ `Model` folder in the sample app, replacing the demo model there.
+
+ *Note: Please use a physical iOS device to run the sample app.*


### PR DESCRIPTION
* Update the TFLite instructions to point to a legacy copy of TFLite sound classification sample, as we'll migrate the sample to use TFLite Task Library.
* Once Teachable Machine completes the migration to export models that are compatible with Task Library, I'll send another pull request to update this snippet to point to the new sample.