### PR TITLE
Upgrade seedrandom dependency

### DIFF
--- a/libraries/image/package.json
+++ b/libraries/image/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "autobind-decorator": "^2.4.0",
-    "seedrandom": "^2.4.3"
+    "seedrandom": "^3.0.5"
   }
 }


### PR DESCRIPTION
Seedrandom beginning from 3.0.5 version stoped using eval so it's more safe and can be used in environements where it's forbidden (i.e. mv3 extensions).

Please, check https://github.com/googlecreativelab/teachablemachine-community/issues/233 issue